### PR TITLE
Closes #244: Fix duplicated LocationIDs in GLA

### DIFF
--- a/R/format_GLA.R
+++ b/R/format_GLA.R
@@ -13,6 +13,8 @@
 #'\strong{IndvID}: Should be a 7 digit alphanumeric string. IndvIDs with a different number of characters are likely errors.
 #'These are set to NA and removed.
 #'
+#'\strong{LocationID}: LocationIDs are formatted as <PopID>_<NestboxNumber> to avoid duplicates.
+#'
 #'\strong{CaptureDate}: Some individuals were not recorded in the ringing records, but were observed breeding at a monitored nest.
 #'For these individuals, the CaptureDate is set as May 15 of the breeding year.
 #'
@@ -77,7 +79,7 @@ format_GLA <- function(db = choose_directory(),
 
     ## Reformat and rename important variables
     dplyr::mutate(BreedingSeason = as.integer(.data$Yr),
-                  LocationID = as.character(.data$NestboxNumber),
+                  NestboxNumber = as.character(.data$NestboxNumber),
                   Species = as.character(.data$Species),
                   PopID = as.character(.data$Site)) %>%
 
@@ -103,7 +105,7 @@ format_GLA <- function(db = choose_directory(),
                   ClutchSize = as.integer(.data$ClutchSize)) %>%
 
     ## Arrange
-    dplyr::arrange(.data$PopID, .data$BreedingSeason, .data$LocationID, .data$FirstEggDate) %>%
+    dplyr::arrange(.data$PopID, .data$BreedingSeason, .data$NestboxNumber, .data$FirstEggDate) %>%
 
     ## Create additional variables that will be used in multiple data tables
     dplyr::mutate(ClutchSize_max = dplyr::case_when(.data$ClutchComplete == "TRUE" ~ as.numeric(.data$ClutchSize),
@@ -138,7 +140,7 @@ format_GLA <- function(db = choose_directory(),
     ## Select variables of interest
     dplyr::select("BreedingSeason",
                   "PopID",
-                  "LocationID",
+                  "NestboxNumber",
                   "Species",
                   "ReplacementClutch",
                   "LayDate_observed",
@@ -174,7 +176,6 @@ format_GLA <- function(db = choose_directory(),
     dplyr::rename("BreedingSeason" = "Yr",
                   "PopID" = "Site",
                   "IndvID" = "RingNumber",
-                  "LocationID" = "NestboxNumber",
                   "CaptureDate" = "Date",
                   "CaptureTime" = "Time",
                   "ObserverID" = "Initial",
@@ -254,6 +255,12 @@ format_GLA <- function(db = choose_directory(),
   message("Compiling location information...")
   Location_data <- create_location_GLA(nest_data, rr_data, protocol_version)
 
+  # Add missing columns
+  Brood_data <- Brood_data %>%
+    dplyr::bind_cols(data_templates[[paste0("v", protocol_version)]]$Brood_data[1, !(names(data_templates[[paste0("v", protocol_version)]]$Brood_data) %in% names(.))]) %>%
+    # Keep only columns that are in the standard format and order correctly
+    dplyr::select(names(data_templates[[paste0("v", protocol_version)]]$Brood_data))
+
   time <- difftime(Sys.time(), start_time, units = "sec")
 
   message(paste0("All tables generated in ", round(time, 2), " seconds"))
@@ -312,7 +319,7 @@ create_brood_GLA <- function(nest_data, rr_data, protocol_version) {
 
   ## Get brood data from ringing records
   rr_data_brood_sum <- rr_data %>%
-    dplyr::filter(!is.na(.data$LocationID)) %>%
+    dplyr::filter(!is.na(.data$NestboxNumber)) %>%
 
     ## Determine whether a chick or adult
     dplyr::mutate(RingAge = ifelse(.data$Age_observed == 1, "chick", "adult")) %>%
@@ -321,7 +328,7 @@ create_brood_GLA <- function(nest_data, rr_data, protocol_version) {
     dplyr::filter(.data$RingAge == "chick") %>%
 
     ## Summarize brood information for each nest
-    dplyr::group_by(.data$BreedingSeason, .data$PopID, .data$Species, .data$LocationID) %>%
+    dplyr::group_by(.data$BreedingSeason, .data$PopID, .data$Species, .data$NestboxNumber) %>%
 
     ## If any chicks reach the age where they can be ringed at a nest box, that nest box will not be used again in the breeding season
     ## As such, for each location with chicks, there is only going to be one FemaleID and one MaleID
@@ -336,7 +343,7 @@ create_brood_GLA <- function(nest_data, rr_data, protocol_version) {
                    AvgTarsus = round(mean(.data$Tarsus[.data$ChickAge <= 16L & .data$ChickAge >= 14L ], na.rm = TRUE),1),
                    NumberChicksTarsus = sum(.data$ChickAge <= 16L & .data$ChickAge >= 14L & is.na(.data$Tarsus) == FALSE)) %>%
     dplyr::distinct() %>%
-    dplyr::group_by(.data$BreedingSeason, .data$PopID, .data$Species, .data$LocationID) %>%
+    dplyr::group_by(.data$BreedingSeason, .data$PopID, .data$Species, .data$NestboxNumber) %>%
 
     ## Replace NaNs and 0 with NA
     dplyr::mutate(dplyr::across(tidyselect::where(is.numeric), ~dplyr::na_if(., NaN)),
@@ -352,7 +359,7 @@ create_brood_GLA <- function(nest_data, rr_data, protocol_version) {
 
   ## Join brood data from ringing records to brood data from nest records
   Brood_data <- nest_data_brood_sum %>%
-    dplyr::group_by(.data$BreedingSeason, .data$PopID, .data$Species, .data$LocationID) %>%
+    dplyr::group_by(.data$BreedingSeason, .data$PopID, .data$Species, .data$NestboxNumber) %>%
     dplyr::mutate(last_rec = dplyr::case_when(.data$BroodID == max(.data$BroodID) ~ "yes",
                                               TRUE ~ "no")) %>%
 
@@ -361,7 +368,7 @@ create_brood_GLA <- function(nest_data, rr_data, protocol_version) {
     dplyr::left_join(rr_data_brood_sum %>%
                        dplyr::mutate(chicks_fledged = dplyr::case_when(!is.na(.data$NumberChicksMass) | !is.na(.data$NumberChicksTarsus) ~ "yes",
                                                                         TRUE ~ "no")),
-                     by = c("BreedingSeason", "PopID", "LocationID")) %>%
+                     by = c("BreedingSeason", "PopID", "NestboxNumber")) %>%
     dplyr::select(-"chicks_fledged", -"last_rec") %>%
 
     ## Merge Male and Female ID columns to fill in any that are missing
@@ -399,12 +406,9 @@ create_brood_GLA <- function(nest_data, rr_data, protocol_version) {
     dplyr::arrange(.data$PopID, .data$BreedingSeason, .data$Species, .data$FemaleID, .data$LayDate_observed) %>%
     dplyr::ungroup() %>%
     dplyr::mutate(ClutchType_calculated = calc_clutchtype(data =. , protocol_version = "1.1", na.rm = FALSE)) %>%
-
-    ## Add missing columns
-    dplyr::bind_cols(data_templates[[paste0("v", protocol_version)]]$Brood_data[1, !(names(data_templates[[paste0("v", protocol_version)]]$Brood_data) %in% names(.))]) %>%
-
-    ## Keep only columns that are in the standard format and order correctly
-    dplyr::select(names(data_templates[[paste0("v", protocol_version)]]$Brood_data))
+    # Add PopID prefix to LocationID to avoid duplicated LocationIDs across sites
+    dplyr::mutate(LocationID = dplyr::case_when(is.na(.data$NestboxNumber) ~ NA_character_,
+                                                TRUE ~ paste(.data$PopID, .data$NestboxNumber, sep = "_")))
 
   return(Brood_data)
 
@@ -427,7 +431,7 @@ create_capture_GLA <- function(nest_data, rr_data, Brood_data, protocol_version)
   ## Capture data from ringing records
   ## TODO: Check on tarsus method
   Capture_data_rr <- rr_data %>%
-    dplyr::filter(!(.data$IndvID %in% c("too small", "too_small", "no_rings_COVID","unknown"))) %>% # Keep only records of banded individuals
+    dplyr::filter(!(.data$IndvID %in% c("too small", "too_small", "no_rings_COVID", "unknown"))) %>% # Keep only records of banded individuals
 
     ## Join Experiment info for chicks
     dplyr::filter(.data$Age == 1L) %>%
@@ -437,13 +441,13 @@ create_capture_GLA <- function(nest_data, rr_data, Brood_data, protocol_version)
                        dplyr::filter(!is.na(.data$ExperimentID)) %>%
                        dplyr::select("BreedingSeason",
                                      "PopID",
-                                     "LocationID",
+                                     "NestboxNumber",
                                      "ExperimentID"),
-                     by = c("BreedingSeason", "PopID","LocationID")) %>%
+                     by = c("BreedingSeason", "PopID", "NestboxNumber")) %>%
 
     ## Add in adults. Create ExperimentID column separately for this group if radio tagged
     dplyr::bind_rows(rr_data %>%
-                       dplyr::filter(!(.data$IndvID %in% c("too small", "too_small", "no_rings_COVID","unknown"))) %>% # Keep only records of banded individuals
+                       dplyr::filter(!(.data$IndvID %in% c("too small", "too_small", "no_rings_COVID", "unknown"))) %>% # Keep only records of banded individuals
                        dplyr::filter(.data$Age != 1L | is.na(.data$Age)) %>%
                        dplyr::mutate(ExperimentID = dplyr::case_when(.data$RadioTagFitted == TRUE | .data$RfidFitted == TRUE ~ "SURVIVAL"))) %>%
 
@@ -457,13 +461,8 @@ create_capture_GLA <- function(nest_data, rr_data, Brood_data, protocol_version)
                   ReleaseAlive = dplyr::case_when(.data$Retrap == "X" | .data$Age == "X" ~ FALSE,
                                                   .data$Retrap %in% c("N", "R", "C", "U", NA) ~ TRUE), ## Set ReleaseAlive to FALSE if Retrap is X or if Age is X (chick found dead at nest)
                   ReleasePopID = dplyr::case_when(.data$ReleaseAlive == FALSE ~ NA_character_,
-                                                  TRUE ~ as.character(.data$CapturePopID))) %>%  ## Set ReleasePopID to NA if ReleaseAlive is FALSE, otherwise same as CapturePopID
+                                                  TRUE ~ as.character(.data$CapturePopID))) ## Set ReleasePopID to NA if ReleaseAlive is FALSE, otherwise same as CapturePopID
 
-    ## Add missing columns
-    dplyr::bind_cols(data_templates[[paste0("v", protocol_version)]]$Capture_data[1, !(names(data_templates[[paste0("v", protocol_version)]]$Capture_data) %in% names(.))]) %>%
-
-    ## Keep only columns that are in the standard format and order correctly
-    dplyr::select(names(data_templates[[paste0("v", protocol_version)]]$Capture_data))
 
 
   ## Create capture data from nest data.
@@ -490,18 +489,11 @@ create_capture_GLA <- function(nest_data, rr_data, Brood_data, protocol_version)
                   CaptureAlive = TRUE, ## Set CaptureAlive to T
                   ReleaseAlive = TRUE) %>% ## Set ReleaseAlive to T
 
-    dplyr::ungroup() %>%
-
-    ## Add missing columns
-    dplyr::bind_cols(data_templates[[paste0("v", protocol_version)]]$Capture_data[1, !(names(data_templates[[paste0("v", protocol_version)]]$Capture_data) %in% names(.))]) %>%
-
-    ## Keep only columns that are in the standard format and order correctly
-    dplyr::select(names(data_templates[[paste0("v", protocol_version)]]$Capture_data))
-
+    dplyr::ungroup()
 
   ## Get records of individuals that were reported in the nest data, but not in the ringing records
   brood_recs_unique <- dplyr::anti_join(Capture_data_nest, Capture_data_rr,
-                                        by = c("BreedingSeason", "CapturePopID", "IndvID","LocationID"))
+                                        by = c("BreedingSeason", "CapturePopID", "IndvID","NestboxNumber"))
 
   ## Combine captures and add additional information
   Capture_data <- Capture_data_rr %>%
@@ -512,6 +504,9 @@ create_capture_GLA <- function(nest_data, rr_data, Brood_data, protocol_version)
                                    TRUE ~ NA_character_)) %>%
     dplyr::filter(!is.na(.data$IndvID)) %>%
 
+    # Add PopID prefix to LocationID to avoid duplicated LocationIDs across sites
+    dplyr::mutate(LocationID = dplyr::case_when(is.na(.data$NestboxNumber) ~ NA_character_,
+                                                TRUE ~ paste(.data$PopID, .data$NestboxNumber, sep = "_"))) %>%
     ##  Change column class
     dplyr::mutate(BreedingSeason = as.integer(.data$BreedingSeason)) %>%
 
@@ -666,26 +661,29 @@ create_location_GLA <- function(nest_data, rr_data, protocol_version) {
   ## Then join nest data
   ## No nest boxes have been removed
   Location_data <- rr_data %>%
-    dplyr::select("BreedingSeason", "PopID", "LocationID") %>%
-    dplyr::filter(!is.na(.data$LocationID)) %>%
+    dplyr::select("BreedingSeason", "PopID", "NestboxNumber") %>%
+    dplyr::filter(!is.na(.data$NestboxNumber)) %>%
 
     ## Add in locations from nest data
     dplyr::bind_rows(nest_data %>%
-                       dplyr::select("BreedingSeason", "PopID", "LocationID") %>%
-                       dplyr::filter(!is.na(.data$LocationID))) %>%
+                       dplyr::select("BreedingSeason", "PopID", "NestboxNumber") %>%
+                       dplyr::filter(!is.na(.data$NestboxNumber))) %>%
 
     ## Keep distinct records
-    dplyr::distinct(.data$PopID, .data$BreedingSeason, .data$LocationID, .keep_all = TRUE) %>%
+    dplyr::distinct(.data$PopID, .data$BreedingSeason, .data$NestboxNumber, .keep_all = TRUE) %>%
 
     ## All records shows be complete: remove any incomplete cases
     tidyr::drop_na() %>%
 
     ## Get additional information
-    dplyr::group_by(.data$PopID, .data$LocationID) %>%
+    dplyr::group_by(.data$PopID, .data$NestboxNumber) %>%
     dplyr::summarise(StartSeason = min(.data$BreedingSeason, na.rm = TRUE),
                      EndSeason = NA_integer_) %>%
     dplyr::ungroup() %>%
-    dplyr::mutate(NestboxID = .data$LocationID,
+    dplyr::mutate(NestboxID = .data$NestboxNumber,
+                  # Add PopID prefix to LocationID to avoid duplicated LocationIDs across sites
+                  LocationID = dplyr::case_when(is.na(.data$NestboxNumber) ~ NA_character_,
+                                                TRUE ~ paste(.data$PopID, .data$NestboxNumber, sep = "_")),
                   LocationType = "NB",
                   HabitatType = dplyr::case_when(.data$PopID == "GAR" ~ "urban",
                                                  .data$PopID == "CAS" ~ "deciduous",

--- a/man/format_GLA.Rd
+++ b/man/format_GLA.Rd
@@ -48,6 +48,8 @@ this data. For a general description of the standard format please see
 \strong{IndvID}: Should be a 7 digit alphanumeric string. IndvIDs with a different number of characters are likely errors.
 These are set to NA and removed.
 
+\strong{LocationID}: LocationIDs are formatted as <PopID>_<NestboxNumber> to avoid duplicates.
+
 \strong{CaptureDate}: Some individuals were not recorded in the ringing records, but were observed breeding at a monitored nest.
 For these individuals, the CaptureDate is set as May 15 of the breeding year.
 }

--- a/tests/testthat/test-GLA.R
+++ b/tests/testthat/test-GLA.R
@@ -72,67 +72,67 @@ test_that("Brood_data returns an expected outcome...", {
   ## General brood data
   expect_equal(subset(GLA_data, BreedingSeason == "2014"
                       & PopID == "GAR"
-                      & LocationID == "704")$ClutchSize_observed, 10)
+                      & LocationID == "GAR_704")$ClutchSize_observed, 10)
   expect_equal(subset(GLA_data, BreedingSeason == "2014"
                       & PopID == "GAR"
-                      & LocationID == "704")$BroodSize_observed, 9)
+                      & LocationID == "GAR_704")$BroodSize_observed, 9)
   expect_equal(subset(GLA_data, BreedingSeason == "2014"
                       & PopID == "GAR"
-                      & LocationID == "704")$NumberFledged_observed, 9)
+                      & LocationID == "GAR_704")$NumberFledged_observed, 9)
   expect_equal(subset(GLA_data, BreedingSeason == "2014"
                       & PopID == "GAR"
-                      & LocationID == "704")$LayDate_observed, as.Date("2014-04-25"))
+                      & LocationID == "GAR_704")$LayDate_observed, as.Date("2014-04-25"))
   expect_equal(subset(GLA_data, BreedingSeason == "2014"
                       & PopID == "GAR"
-                      & LocationID == "704")$LayDate_min, lubridate::NA_Date_)
+                      & LocationID == "GAR_704")$LayDate_min, lubridate::NA_Date_)
   expect_equal(subset(GLA_data, BreedingSeason == "2014"
                       & PopID == "GAR"
-                      & LocationID == "704")$LayDate_max, lubridate::NA_Date_)
+                      & LocationID == "GAR_704")$LayDate_max, lubridate::NA_Date_)
 
   ## Case where there were multiple clutches laid at the same location
   expect_equal(nrow(subset(GLA_data, BreedingSeason == "2019"
                            & PopID == "SAL"
-                           & LocationID == "249")), 2)
+                           & LocationID == "SAL_249")), 2)
 
   ## Brood where clutch type observed = replacement
   expect_equal(subset(GLA_data, BreedingSeason == "2015"
                       & PopID == "SAL"
-                      & LocationID == "235" &
+                      & LocationID == "SAL_235" &
                         is.na(LayDate_observed))$ClutchType_observed, "replacement")
 
   ## Brood where chick weight, but not tarsus is measured
   expect_equal(subset(GLA_data,
                       BreedingSeason == "2018"
                       & PopID == "CAS"
-                      & LocationID == "28")$AvgChickMass, 10.1)
+                      & LocationID == "CAS_28")$AvgChickMass, 10.1)
   expect_equal(subset(GLA_data,
                       BreedingSeason == "2018"
                       & PopID == "CAS"
-                      & LocationID == "28")$NumberChicksMass, 8)
+                      & LocationID == "CAS_28")$NumberChicksMass, 8)
   expect_equal(subset(GLA_data,
                       BreedingSeason == "2018"
                       & PopID == "CAS"
-                      & LocationID == "28")$AvgTarsus, NA_real_)
+                      & LocationID == "CAS_28")$AvgTarsus, NA_real_)
   expect_equal(subset(GLA_data,
                       BreedingSeason == "2018"
                       & PopID == "CAS"
-                      & LocationID == "28")$NumberChicksTarsus, NA_integer_)
+                      & LocationID == "CAS_28")$NumberChicksTarsus, NA_integer_)
 
   ## Case where species is ambiguous, but the species information from the ringing data  was used to assign species for the brood
   expect_equal(subset(GLA_data,
                       BreedingSeason == "2020"
                       & PopID == "SAL"
-                      & LocationID == "204")$Species, "PARMAJ")
+                      & LocationID == "SAL_204")$Species, "PARMAJ")
 
   ## Case where both FemaleID and MaleID are known
   expect_equal(subset(GLA_data,
                       BreedingSeason == "2020"
                       & PopID == "KEL"
-                      & LocationID == "534")$FemaleID, "ACJ2320")
+                      & LocationID == "KEL_534")$FemaleID, "ACJ2320")
   expect_equal(subset(GLA_data,
                       BreedingSeason == "2020"
                       & PopID == "KEL"
-                      & LocationID == "534")$MaleID, "ACJ2305")
+                      & LocationID == "KEL_534")$MaleID, "ACJ2305")
 
   ## Case where female had two nests in the same year
   expect_equal(nrow(subset(GLA_data, FemaleID == "TX11502" & BreedingSeason == 2017)), 2)
@@ -141,59 +141,59 @@ test_that("Brood_data returns an expected outcome...", {
   expect_equal(subset(GLA_data,
                       BreedingSeason == "2014"
                       & PopID == "GAR"
-                      & LocationID == "710")$LayDate_observed, as.Date("2014-05-05"))
+                      & LocationID == "GAR_710")$LayDate_observed, as.Date("2014-05-05"))
   expect_equal(subset(GLA_data,
                       BreedingSeason == "2014"
                       & PopID == "GAR"
-                      & LocationID == "710")$LayDate_max, lubridate::NA_Date_)
+                      & LocationID == "GAR_710")$LayDate_max, lubridate::NA_Date_)
   expect_equal(subset(GLA_data,
                       BreedingSeason == "2014"
                       & PopID == "GAR"
-                      & LocationID == "729")$LayDate_max, lubridate::NA_Date_)
+                      & LocationID == "GAR_729")$LayDate_max, lubridate::NA_Date_)
   expect_equal(subset(GLA_data,
                       BreedingSeason == "2014"
                       & PopID == "GAR"
-                      & LocationID == "724")$LayDate_min, lubridate::NA_Date_)
+                      & LocationID == "GAR_724")$LayDate_min, lubridate::NA_Date_)
   expect_equal(subset(GLA_data,
                       BreedingSeason == "2015"
                       & PopID == "GAR"
-                      & LocationID == "724")$LayDate_min, lubridate::NA_Date_)
+                      & LocationID == "GAR_724")$LayDate_min, lubridate::NA_Date_)
   expect_equal(subset(GLA_data,
                       BreedingSeason == "2017"
                       & PopID == "SAL"
-                      & LocationID == "227")$LayDate_min, lubridate::NA_Date_)
+                      & LocationID == "SAL_227")$LayDate_min, lubridate::NA_Date_)
 
   ## Check experiment groups
   expect_equal(subset(GLA_data,
                       BreedingSeason == "2016"
                       & PopID == "KEL"
-                      & LocationID == "548")$ExperimentID, "PARENTAGE")
+                      & LocationID == "KEL_548")$ExperimentID, "PARENTAGE")
 
   expect_equal(subset(GLA_data,
                       BreedingSeason == "2016"
                       & PopID == "KEL"
-                      & LocationID == "550")$ExperimentID, "OTHER")
+                      & LocationID == "KEL_550")$ExperimentID, "OTHER")
 
   expect_equal(subset(GLA_data,
                       BreedingSeason == "2017"
                       & PopID == "SCE"
-                      & LocationID == "41")$ExperimentID, "OTHER")
+                      & LocationID == "SCE_41")$ExperimentID, "OTHER")
 
   expect_equal(subset(GLA_data,
                       BreedingSeason == "2018"
                       & PopID == "SCE"
-                      & LocationID == "175")$ExperimentID, "OTHER")
+                      & LocationID == "SCE_175")$ExperimentID, "OTHER")
 
   expect_equal(subset(GLA_data,
                       BreedingSeason == "2019"
                       & PopID == "SAL"
-                      & LocationID == "229")$ExperimentID, "COHORT")
+                      & LocationID == "SAL_229")$ExperimentID, "COHORT")
 
   ## Check incorrect IDs
   expect_equal(subset(GLA_data,
                       BreedingSeason == "2018"
                       & PopID == "SCE"
-                      & LocationID == "51")$MaleID, NA_character_)
+                      & LocationID == "SCE_51")$MaleID, NA_character_)
 
 
 
@@ -218,7 +218,7 @@ test_that("Capture_data returns an expected outcome...", {
   expect_equal(subset(GLA_data, IndvID == "S034047" &
                         BreedingSeason == 2017)$Sex_observed, "F") # Female
   expect_equal(subset(GLA_data, IndvID == "S034047" &
-                        CaptureDate == as.Date("2018-05-01"))$LocationID, "65") # LocationID 65
+                        CaptureDate == as.Date("2018-05-01"))$LocationID, "CAS_65") # Nestbox 65 in CAS
 
   ## Check that all IndvIDs conform to expected format
   expect_true(all(stringr::str_detect(subset(GLA_data)$IndvID, "^[[:digit:][:alpha:]]{7}$")))
@@ -231,18 +231,18 @@ test_that("Location_data returns an expected outcome...", {
   GLA_data <- dplyr::filter(pipeline_output$Location_data, PopID %in% c("CAS", "GAR", "KEL", "SAL", "SCE"))
 
   ## Nestbox 728 in GAR
-  expect_equal(subset(GLA_data, LocationID == "728" &
+  expect_equal(subset(GLA_data, LocationID == "GAR_728" &
                         PopID == "GAR")$LocationType, "NB") ## Nestbox
-  expect_equal(subset(GLA_data, LocationID == "728" &
+  expect_equal(subset(GLA_data, LocationID == "GAR_728" &
                         PopID == "GAR")$HabitatType, "urban") ## Urban
-  expect_equal(subset(GLA_data, LocationID == "728" &
+  expect_equal(subset(GLA_data, LocationID == "GAR_728" &
                         PopID == "GAR")$StartSeason, 2015) ## 2015
-  expect_equal(subset(GLA_data, LocationID == "728" &
+  expect_equal(subset(GLA_data, LocationID == "GAR_728" &
                         PopID == "GAR")$EndSeason, NA_integer_) ## NA
 
   ## Same nestbox number at 3 populations
   #LocationType is as expected
-  expect_equal(subset(GLA_data, LocationID == "10")$PopID, c("CAS", "KEL", "SCE"))
+  expect_equal(subset(GLA_data, NestboxID == "10")$PopID, c("CAS", "KEL", "SCE"))
 
 
 })


### PR DESCRIPTION
Duplicated `LocationID` values across sites (`PopID`) within a single pipeline result in an error in the ICM system (#244). To avoid that, we add a `PopID` prefix to nestbox number that was previously used as `LocationID`. 

The easiest implementation I saw was using the original variable `NestboxNumber` as a location identifier in the pipelines and only create `LocationID` (`PopID`_`NestboxNumber`) after other data wrangling was done. 