### PR TITLE
Fix protocol violations in AMM brood data

### DIFF
--- a/R/format_AMM.R
+++ b/R/format_AMM.R
@@ -248,19 +248,28 @@ create_brood_AMM <- function(dir, species_filter) {
       LayDate_min = .data$EndMarch + (.data$FirstEggDay - .data$FirstEggDayError),
       ClutchSize_observed = .data$ClutchSize,
       ClutchSize_min = .data$ClutchSize_observed,
-      ClutchSize_max = .data$ClutchSize_observed,
+      ClutchSize_max = dplyr::case_when(
+        .data$ClutchSize_observed == 0 ~ NA_integer_,
+        TRUE ~ .data$ClutchSize_observed
+      ),
       HatchDate_observed = .data$EndMarch + .data$HatchDay,
       HatchDate_max = .data$HatchDate_observed,
       HatchDate_min = .data$EndMarch + (.data$HatchDay - .data$HatchDayError),
       BroodSize_observed = .data$NumberHatched,
       BroodSize_min = .data$NumberHatched,
-      BroodSize_max = .data$NumberHatched + .data$ErrorHatched,
+      BroodSize_max = dplyr::case_when(
+        .data$NumberHatched == 0 ~ NA_integer_,
+        TRUE ~ .data$NumberHatched + .data$ErrorHatched
+      ),
       FledgeDate_observed = .data$EndMarch + .data$FledgeDay,
       FledgeDate_min = .data$EndMarch + .data$FledgeDay,
       FledgeDate_max = .data$EndMarch + .data$FledgeDay,
       NumberFledged_observed = .data$NumberFledged,
       NumberFledged_min = .data$NumberFledged,
-      NumberFledged_max = .data$NumberFledged + .data$FledgedError,
+      NumberFledged_max = dplyr::case_when(
+        .data$NumberFledged == 0 ~ NA_integer_,
+        TRUE ~ .data$NumberFledged + .data$FledgedError
+      ),
       Species = dplyr::case_when(
         .data$Species == 1L ~ !!species_codes$Species[species_codes$speciesEURINGCode == "14640"],
         .data$Species == 2L ~ !!species_codes$Species[species_codes$speciesEURINGCode == "14620"],

--- a/tests/testthat/test-AMM.R
+++ b/tests/testthat/test-AMM.R
@@ -57,7 +57,7 @@ test_that("Brood_data returns an expected outcome...", {
   expect_equal(subset(AMM_data, BroodID == "4375")$FledgeDate_max, as.Date(NA))
   expect_equal(subset(AMM_data, BroodID == "4375")$NumberFledged_observed, 0L)
   expect_equal(subset(AMM_data, BroodID == "4375")$NumberFledged_min, 0L)
-  expect_equal(subset(AMM_data, BroodID == "4375")$NumberFledged_max, 0L)
+  expect_equal(subset(AMM_data, BroodID == "4375")$NumberFledged_max, NA_integer_)
   #Measurements taken but not included in average because chick age was >16
   expect_equal(subset(AMM_data, BroodID == "4375")$AvgChickMass, NA_real_)
   expect_equal(subset(AMM_data, BroodID == "4375")$AvgTarsus, 20.25)


### PR DESCRIPTION
For `ClutchSize_max`, `BroodSize_max` and `NumberFledged_max`, the ICM system expects a lower bound of 1. Some brood records in AMM had `<X>_max` values of 0, which are now set to `NA`. 

PR closes #264.